### PR TITLE
Add support for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # "gate" for your private resources
 
-gate is a static file server and reverse proxy integrated with google account authentications.
+gate is a static file server and reverse proxy integrated with Google/GitHub account authentication.
 
-With gate, you can safely serve your private resources with your company google apps authenticaiton.
+With gate, you can safely serve your private resources with your company Google Apps/GitHub authenticaiton.
 
 ## Usage
 
@@ -16,25 +16,27 @@ With gate, you can safely serve your private resources with your company google 
 # address to bind
 address: :9999
 
-# # ssl keys (optional)
-# ssl:
-#   cert: ./ssl/ssl.cer
-#   key: ./ssl/ssl.key
+# ssl keys (optional)
+ssl:
+  cert: ./ssl/ssl.cer
+  key: ./ssl/ssl.key
 
 auth:
   session:
     # authentication key for cookie store
     key: secret123
 
-  google:
+  info:
+    service: google
     # your google app keys
     client_id: your client id
     client_secret: your client secret
     # your google app redirect_url: path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
-# # restrict domain. (optional)
-# domain: yourdomain.com
+# restrict domain. (optional)
+conditions:
+  - yourdomain.com
 
 # document root for static files
 htdocs: ./
@@ -48,7 +50,44 @@ proxy:
   - path: /influxdb
     dest: http://127.0.0.1:8086
     strip_path: yes
+```
 
+## Authentication Strategy
+
+gate now supports Google Apps and GitHub to authenticate users.
+
+### Example config for Google
+
+```yaml
+auth:
+  info:
+    service: google
+    client_id: your client id
+    client_secret: your client secret
+    redirect_url: https://yourapp.example.com/oauth2callback
+
+# restrict domain. (optional)
+conditions:
+  - example.com
+  - you@example.com
+```
+
+### Example config for GitHub
+
+Unlike the example of Google Apps above, if the `service` is GitHub, gate uses whether request user is a member of organization designated like below:
+
+```yaml
+auth:
+  info:
+    service: github
+    client_id: your client id
+    client_secret: your client secret
+    redirect_url: https://yourapp.example.com/oauth2callback
+
+# restrict organization (optional)
+conditions:
+  - foo_organization
+  - bar_organization
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # "gate" for your private resources
 
-gate is a static file server and reverse proxy integrated with Google/GitHub account authentication.
+gate is a static file server and reverse proxy integrated with OAuth2 account authentication.
 
-With gate, you can safely serve your private resources with your company Google Apps/GitHub authenticaiton.
+With gate, you can safely serve your private resources based on whether or not request user is a member of your company's Google Apps or GitHub organizations.
 
 ## Usage
 
@@ -16,10 +16,10 @@ With gate, you can safely serve your private resources with your company Google 
 # address to bind
 address: :9999
 
-# ssl keys (optional)
-ssl:
-  cert: ./ssl/ssl.cer
-  key: ./ssl/ssl.key
+# # ssl keys (optional)
+# ssl:
+#   cert: ./ssl/ssl.cer
+#   key: ./ssl/ssl.key
 
 auth:
   session:
@@ -27,16 +27,19 @@ auth:
     key: secret123
 
   info:
+    # oauth2 provider name (`google` or `github`)
     service: google
-    # your google app keys
+    # your app keys for the service
     client_id: your client id
     client_secret: your client secret
-    # your google app redirect_url: path is always "/oauth2callback"
+    # your app redirect_url for the service: if the service is Google, path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
-# restrict domain. (optional)
-conditions:
-  - yourdomain.com
+# # restrict user request. (optional)
+# restrictions:
+#   - yourdomain.com    # domain of your Google App (Google)
+#   - example@gmail.com # specific email address (same as above)
+#   - your_company_org  # organization name (GitHub)
 
 # document root for static files
 htdocs: ./
@@ -66,10 +69,10 @@ auth:
     client_secret: your client secret
     redirect_url: https://yourapp.example.com/oauth2callback
 
-# restrict domain. (optional)
-conditions:
-  - example.com
-  - you@example.com
+# restrict user request. (optional)
+restrictions:
+  - yourdomain.com    # domain of your Google App
+  - example@gmail.com # specific email address
 ```
 
 ### Example config for GitHub
@@ -84,8 +87,8 @@ auth:
     client_secret: your client secret
     redirect_url: https://yourapp.example.com/oauth2callback
 
-# restrict organization (optional)
-conditions:
+# restrict user request. (optional)
+restrictions:
   - foo_organization
   - bar_organization
 ```

--- a/authenticator.go
+++ b/authenticator.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/go-martini/martini"
+	gooauth2 "github.com/golang/oauth2"
+	"github.com/martini-contrib/oauth2"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type Authenticator interface {
+	Authenticate([]string, martini.Context, oauth2.Tokens, http.ResponseWriter, *http.Request)
+}
+
+func NewAuthenticator(conf *Conf) Authenticator {
+	var a Authenticator
+
+	if conf.Auth.Info.Service == "google" {
+		oauth := oauth2.Google(&gooauth2.Options{
+			ClientID:     conf.Auth.Info.ClientId,
+			ClientSecret: conf.Auth.Info.ClientSecret,
+			RedirectURL:  conf.Auth.Info.RedirectURL,
+			Scopes:       []string{"email"},
+		})
+		a = &GoogleAuth{oauth}
+	} else if conf.Auth.Info.Service == "github" {
+		oauth := oauth2.Github(&gooauth2.Options{
+			ClientID:     conf.Auth.Info.ClientId,
+			ClientSecret: conf.Auth.Info.ClientSecret,
+			RedirectURL:  conf.Auth.Info.RedirectURL,
+			Scopes:       []string{"user:email"},
+		})
+		a = &GitHubAuth{oauth}
+	} else {
+		panic("unsupported authentication method")
+	}
+
+	return a
+}
+
+type GoogleAuth struct {
+	martini.Handler
+}
+
+func (a *GoogleAuth) Authenticate(domain []string, c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
+	extra := tokens.ExtraData()
+	if _, ok := extra["id_token"]; ok == false {
+		log.Printf("id_token not found")
+		forbidden(w)
+		return
+	}
+
+	keys := strings.Split(extra["id_token"], ".")
+	if len(keys) < 2 {
+		log.Printf("invalid id_token")
+		forbidden(w)
+		return
+	}
+
+	data, err := base64Decode(keys[1])
+	if err != nil {
+		log.Printf("failed to decode base64: %s", err.Error())
+		forbidden(w)
+		return
+	}
+
+	var info map[string]interface{}
+	if err := json.Unmarshal(data, &info); err != nil {
+		log.Printf("failed to decode json: %s", err.Error())
+		forbidden(w)
+		return
+	}
+
+	if email, ok := info["email"].(string); ok {
+		var user *User
+		if len(domain) > 0 {
+			for _, d := range domain {
+				if strings.Contains(d, "@") {
+					if d == email {
+						user = &User{email}
+					}
+				} else {
+					if strings.HasSuffix(email, "@"+d) {
+						user = &User{email}
+						break
+					}
+				}
+			}
+		} else {
+			user = &User{email}
+		}
+
+		if user != nil {
+			log.Printf("user %s logged in", email)
+			c.Map(user)
+		} else {
+			log.Printf("email doesn't allow: %s", email)
+			forbidden(w)
+			return
+		}
+	} else {
+		log.Printf("email not found")
+		forbidden(w)
+		return
+	}
+}
+
+type GitHubAuth struct {
+	martini.Handler
+}
+
+func (a *GitHubAuth) Authenticate(domain []string, c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
+
+}
+
+func forbidden(w http.ResponseWriter) {
+	w.WriteHeader(403)
+	w.Write([]byte("Access denied"))
+}

--- a/authenticator.go
+++ b/authenticator.go
@@ -127,6 +127,7 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 		if err != nil {
 			log.Printf("failed to create a request to retrieve organizations: %s", err)
 			forbidden(w)
+			return
 		}
 
 		req.SetBasicAuth(tokens.Access(), "x-oauth-basic")
@@ -136,6 +137,7 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 		if err != nil {
 			log.Printf("failed to retrieve organizations: %s", err)
 			forbidden(w)
+			return
 		}
 
 		data, err := ioutil.ReadAll(res.Body)
@@ -144,6 +146,7 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 		if err != nil {
 			log.Printf("failed to read body of GitHub response: %s", err)
 			forbidden(w)
+			return
 		}
 
 		var info []map[string]interface{}
@@ -163,6 +166,7 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 
 		log.Print("not a member of designated organizations")
 		forbidden(w)
+		return
 	}
 }
 

--- a/authenticator.go
+++ b/authenticator.go
@@ -153,9 +153,9 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 			return
 		}
 
-		for _, targetOrg := range info {
-			for _, conditionOrg := range organizations {
-				if targetOrg["login"] == conditionOrg {
+		for _, userOrg := range info {
+			for _, org := range organizations {
+				if userOrg["login"] == org {
 					return
 				}
 			}

--- a/conf.go
+++ b/conf.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Conf struct {
-	Addr    string      `yaml:"address"`
-	SSL     SSLConf     `yaml:"ssl"`
-	Auth    AuthConf    `yaml:"auth"`
-	Domain  []string    `yaml:"domain"`
-	Proxies []ProxyConf `yaml:"proxy"`
-	Htdocs  string      `yaml:"htdocs"`
+	Addr       string      `yaml:"address"`
+	SSL        SSLConf     `yaml:"ssl"`
+	Auth       AuthConf    `yaml:"auth"`
+	Conditions []string    `yaml:"conditions"`
+	Proxies    []ProxyConf `yaml:"proxy"`
+	Htdocs     string      `yaml:"htdocs"`
 }
 
 type SSLConf struct {

--- a/conf.go
+++ b/conf.go
@@ -22,14 +22,15 @@ type SSLConf struct {
 
 type AuthConf struct {
 	Session AuthSessionConf `yaml:"session"`
-	Google  AuthGoogleConf  `yaml:"google"`
+	Info    AuthInfoConf    `yaml:"info"`
 }
 
 type AuthSessionConf struct {
 	Key string `yaml:"key"`
 }
 
-type AuthGoogleConf struct {
+type AuthInfoConf struct {
+	Service      string `yaml:"service"`
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
 	RedirectURL  string `yaml:"redirect_url"`
@@ -59,14 +60,17 @@ func ParseConf(path string) (*Conf, error) {
 	if c.Auth.Session.Key == "" {
 		return nil, errors.New("auth.session.key config is required")
 	}
-	if c.Auth.Google.ClientId == "" {
-		return nil, errors.New("auth.google.client_id config is required")
+	if c.Auth.Info.Service == "" {
+		return nil, errors.New("auth.info.service config is required")
 	}
-	if c.Auth.Google.ClientSecret == "" {
-		return nil, errors.New("auth.google.client_secret config is required")
+	if c.Auth.Info.ClientId == "" {
+		return nil, errors.New("auth.info.client_id config is required")
 	}
-	if c.Auth.Google.RedirectURL == "" {
-		return nil, errors.New("auth.google.redirect_url config is required")
+	if c.Auth.Info.ClientSecret == "" {
+		return nil, errors.New("auth.info.client_secret config is required")
+	}
+	if c.Auth.Info.RedirectURL == "" {
+		return nil, errors.New("auth.info.redirect_url config is required")
 	}
 
 	if c.Htdocs == "" {

--- a/conf.go
+++ b/conf.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Conf struct {
-	Addr       string      `yaml:"address"`
-	SSL        SSLConf     `yaml:"ssl"`
-	Auth       AuthConf    `yaml:"auth"`
-	Conditions []string    `yaml:"conditions"`
-	Proxies    []ProxyConf `yaml:"proxy"`
-	Htdocs     string      `yaml:"htdocs"`
+	Addr         string      `yaml:"address"`
+	SSL          SSLConf     `yaml:"ssl"`
+	Auth         AuthConf    `yaml:"auth"`
+	Restrictions []string    `yaml:"restrictions"`
+	Proxies      []ProxyConf `yaml:"proxy"`
+	Htdocs       string      `yaml:"htdocs"`
 }
 
 type SSLConf struct {

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -11,11 +11,12 @@ auth:
     # authentication key for cookie store
     key: secret123
 
-  google:
-    # your google app keys
+  info:
+    service: google
+    # your app keys for the service
     client_id: your client id
     client_secret: your client secret
-    # your google app redirect_url: path is always "/oauth2callback"
+    # your app redirect_url for the service: if the service is Google, path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
 # # restrict domain. (optional)

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -12,6 +12,7 @@ auth:
     key: secret123
 
   info:
+    # oauth2 provider name (`google` or `github`)
     service: google
     # your app keys for the service
     client_id: your client id
@@ -19,10 +20,11 @@ auth:
     # your app redirect_url for the service: if the service is Google, path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
-# # restrict domain. (optional)
-# domain:
-#   - yourdomain.com    # restrict by domain
-#   - example@gmail.com # or specific address
+# # restrict user request. (optional)
+# restrictions:
+#   - yourdomain.com    # domain of your Google App (Google)
+#   - example@gmail.com # specific email address (same as above)
+#   - your_company_org  # organization name (GitHub)
 
 # document root for static files
 htdocs: ./

--- a/config_test.go
+++ b/config_test.go
@@ -50,7 +50,7 @@ proxy:
 	}
 }
 
-func TestParseMultiDomain(t *testing.T) {
+func TestParseMultiConditions(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Error(err)
@@ -80,7 +80,7 @@ proxy:
     dest: http://example.com/bar
     strip_path: yes
 
-domain:
+conditions:
   - 'example1.com'
   - 'example2.com'
 `
@@ -93,12 +93,12 @@ domain:
 		t.Error(err)
 	}
 
-	if len(conf.Domain) != 2 {
-		t.Errorf("unexpected domains num: %d", len(conf.Domain))
+	if len(conf.Conditions) != 2 {
+		t.Errorf("unexpected conditions num: %d", len(conf.Conditions))
 	}
 
-	if conf.Domain[0] != "example1.com" || conf.Domain[1] != "example2.com" {
-		t.Errorf("unexpected domains: %+v", conf.Domain)
+	if conf.Conditions[0] != "example1.com" || conf.Conditions[1] != "example2.com" {
+		t.Errorf("unexpected conditions: %+v", conf.Conditions)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -23,7 +23,8 @@ auth:
   session:
     key: secret
 
-  google:
+  info:
+    service: 'google'
     client_id: 'secret client id'
     client_secret: 'secret client secret'
     redirect_url: 'http://example.com/oauth2callback'
@@ -66,7 +67,8 @@ auth:
   session:
     key: secret
 
-  google:
+  info:
+    service: 'google'
     client_id: 'secret client id'
     client_secret: 'secret client secret'
     redirect_url: 'http://example.com/oauth2callback'

--- a/config_test.go
+++ b/config_test.go
@@ -50,7 +50,7 @@ proxy:
 	}
 }
 
-func TestParseMultiConditions(t *testing.T) {
+func TestParseMultiRestrictions(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Error(err)
@@ -80,7 +80,7 @@ proxy:
     dest: http://example.com/bar
     strip_path: yes
 
-conditions:
+restrictions:
   - 'example1.com'
   - 'example2.com'
 `
@@ -93,12 +93,12 @@ conditions:
 		t.Error(err)
 	}
 
-	if len(conf.Conditions) != 2 {
-		t.Errorf("unexpected conditions num: %d", len(conf.Conditions))
+	if len(conf.Restrictions) != 2 {
+		t.Errorf("unexpected restrictions num: %d", len(conf.Restrictions))
 	}
 
-	if conf.Conditions[0] != "example1.com" || conf.Conditions[1] != "example2.com" {
-		t.Errorf("unexpected conditions: %+v", conf.Conditions)
+	if conf.Restrictions[0] != "example1.com" || conf.Restrictions[1] != "example2.com" {
+		t.Errorf("unexpected restrictions: %+v", conf.Restrictions)
 	}
 }
 

--- a/httpd.go
+++ b/httpd.go
@@ -37,7 +37,7 @@ func (s *Server) Run() error {
 	m.Use(a.Handler())
 
 	m.Use(loginRequired())
-	m.Use(restrictDomain(s.Conf.Domain, a))
+	m.Use(restrictByConditions(s.Conf.Conditions, a))
 
 	for i := range s.Conf.Proxies {
 		p := s.Conf.Proxies[i]
@@ -158,14 +158,14 @@ func base64Decode(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }
 
-func restrictDomain(domain []string, authenticator Authenticator) martini.Handler {
+func restrictByConditions(conditions []string, authenticator Authenticator) martini.Handler {
 	return func(c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
 		// skip websocket
 		if isWebsocket(r) {
 			return
 		}
 
-		authenticator.Authenticate(domain, c, tokens, w, r)
+		authenticator.Authenticate(conditions, c, tokens, w, r)
 	}
 }
 

--- a/httpd.go
+++ b/httpd.go
@@ -10,10 +10,8 @@ import (
 	"strings"
 
 	"encoding/base64"
-	"encoding/json"
 
 	"github.com/go-martini/martini"
-	gooauth2 "github.com/golang/oauth2"
 	"github.com/martini-contrib/oauth2"
 	"github.com/martini-contrib/sessions"
 	"path/filepath"
@@ -33,17 +31,13 @@ func NewServer(conf *Conf) *Server {
 
 func (s *Server) Run() error {
 	m := martini.Classic()
+	a := NewAuthenticator(s.Conf)
 
 	m.Use(sessions.Sessions("session", sessions.NewCookieStore([]byte(s.Conf.Auth.Session.Key))))
-	m.Use(oauth2.Google(&gooauth2.Options{
-		ClientID:     s.Conf.Auth.Google.ClientId,
-		ClientSecret: s.Conf.Auth.Google.ClientSecret,
-		RedirectURL:  s.Conf.Auth.Google.RedirectURL,
-		Scopes:       []string{"email"},
-	}))
+	m.Use(a)
 
 	m.Use(loginRequired())
-	m.Use(restrictDomain(s.Conf.Domain))
+	m.Use(restrictDomain(s.Conf.Domain, a))
 
 	for i := range s.Conf.Proxies {
 		p := s.Conf.Proxies[i]
@@ -88,11 +82,6 @@ func (s *Server) Run() error {
 	} else {
 		return http.ListenAndServe(s.Conf.Addr, m)
 	}
-}
-
-func forbidden(w http.ResponseWriter) {
-	w.WriteHeader(403)
-	w.Write([]byte("Access denied"))
 }
 
 func isWebsocket(r *http.Request) bool {
@@ -169,73 +158,14 @@ func base64Decode(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }
 
-func restrictDomain(domain []string) martini.Handler {
+func restrictDomain(domain []string, authenticator Authenticator) martini.Handler {
 	return func(c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
 		// skip websocket
 		if isWebsocket(r) {
 			return
 		}
 
-		extra := tokens.ExtraData()
-		if _, ok := extra["id_token"]; ok == false {
-			log.Printf("id_token not found")
-			forbidden(w)
-			return
-		}
-
-		keys := strings.Split(extra["id_token"], ".")
-		if len(keys) < 2 {
-			log.Printf("invalid id_token")
-			forbidden(w)
-			return
-		}
-
-		data, err := base64Decode(keys[1])
-		if err != nil {
-			log.Printf("failed to decode base64: %s", err.Error())
-			forbidden(w)
-			return
-		}
-
-		var info map[string]interface{}
-		if err := json.Unmarshal(data, &info); err != nil {
-			log.Printf("failed to decode json: %s", err.Error())
-			forbidden(w)
-			return
-		}
-
-		if email, ok := info["email"].(string); ok {
-			var user *User
-			if len(domain) > 0 {
-				for _, d := range domain {
-					if strings.Contains(d, "@") {
-						if d == email {
-							user = &User{email}
-						}
-					} else {
-						if strings.HasSuffix(email, "@"+d) {
-							user = &User{email}
-							break
-						}
-					}
-				}
-			} else {
-				user = &User{email}
-			}
-
-			if user != nil {
-				log.Printf("user %s logged in", email)
-				c.Map(user)
-			} else {
-				log.Printf("email doesn't allow: %s", email)
-				forbidden(w)
-				return
-			}
-		} else {
-			log.Printf("email not found")
-			forbidden(w)
-			return
-		}
+		authenticator.Authenticate(domain, c, tokens, w, r)
 	}
 }
 

--- a/httpd.go
+++ b/httpd.go
@@ -37,7 +37,7 @@ func (s *Server) Run() error {
 	m.Use(a.Handler())
 
 	m.Use(loginRequired())
-	m.Use(restrictByConditions(s.Conf.Conditions, a))
+	m.Use(restrictRequest(s.Conf.Restrictions, a))
 
 	for i := range s.Conf.Proxies {
 		p := s.Conf.Proxies[i]
@@ -158,14 +158,14 @@ func base64Decode(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }
 
-func restrictByConditions(conditions []string, authenticator Authenticator) martini.Handler {
+func restrictRequest(restrictions []string, authenticator Authenticator) martini.Handler {
 	return func(c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
 		// skip websocket
 		if isWebsocket(r) {
 			return
 		}
 
-		authenticator.Authenticate(conditions, c, tokens, w, r)
+		authenticator.Authenticate(restrictions, c, tokens, w, r)
 	}
 }
 

--- a/httpd.go
+++ b/httpd.go
@@ -34,7 +34,7 @@ func (s *Server) Run() error {
 	a := NewAuthenticator(s.Conf)
 
 	m.Use(sessions.Sessions("session", sessions.NewCookieStore([]byte(s.Conf.Auth.Session.Key))))
-	m.Use(a)
+	m.Use(a.Handler())
 
 	m.Use(loginRequired())
 	m.Use(restrictDomain(s.Conf.Domain, a))


### PR DESCRIPTION
If you merge this pull request, gate will be able to authenticate users also with GitHub OAuth.

In this pull request, I did the things below:
- Made authentication logic abstract
- Added GitHub support based on the abstraction above
- Adopted an authentication strategy based on GitHub organization
- Made some trivial modification onto config file (eg. changed the key name `domain` to `restrictions`, etc)
