### PR TITLE
add github enterprise support

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -34,6 +34,8 @@ type AuthInfoConf struct {
 	ClientId     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
 	RedirectURL  string `yaml:"redirect_url"`
+	Endpoint     string `yaml:"endpoint"`
+	ApiEndpoint  string `yaml:"api_endpoint"`
 }
 
 type ProxyConf struct {
@@ -75,6 +77,13 @@ func ParseConf(path string) (*Conf, error) {
 
 	if c.Htdocs == "" {
 		c.Htdocs = "."
+	}
+
+	if c.Auth.Info.Service == "github" && c.Auth.Info.Endpoint == "" {
+		c.Auth.Info.Endpoint = "https://github.com"
+	}
+	if c.Auth.Info.Service == "github" && c.Auth.Info.ApiEndpoint == "" {
+		c.Auth.Info.ApiEndpoint = "https://api.github.com"
 	}
 
 	return c, nil

--- a/config_test.go
+++ b/config_test.go
@@ -102,3 +102,42 @@ restrictions:
 	}
 }
 
+func TestParseGithubServiceShouldSetDefaultValue(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	data := `---
+address: ":9999"
+
+auth:
+  session:
+    key: secret
+
+  info:
+    service: 'github'
+    client_id: 'secret client id'
+    client_secret: 'secret client secret'
+    redirect_url: 'http://example.com/oauth2callback'
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if conf.Auth.Info.Endpoint != "https://github.com" {
+		t.Errorf("unexpected endpoint address: %s", conf.Auth.Info.Endpoint)
+	}
+	if conf.Auth.Info.ApiEndpoint != "https://api.github.com" {
+		t.Errorf("unexpected api endpoint address: %s", conf.Auth.Info.ApiEndpoint)
+	}
+}


### PR DESCRIPTION
Nice application:) I'd like to add github enterprise support for this.

Added *Conf value to BaseAuth struct. Probably, Authenticator shouldn't have conf, 
Though It's very handy for support this feature. 

Seemingly, martini-contrib/oauth2 doesn't support github enterprise directly. At this time, I've wrapped NewOAuth2Provider function as well as `oauth2.Github`.

https://github.com/martini-contrib/oauth2/blob/master/oauth2.go#L109

Could you review my approach when you have a chance?
Thanks,
