### PR TITLE
github: add insecure flag

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"fmt"
+	"crypto/tls"
 )
 
 type Authenticator interface {
@@ -142,7 +143,10 @@ func (a *GitHubAuth) Authenticate(organizations []string, c martini.Context, tok
 
 		req.SetBasicAuth(tokens.Access(), "x-oauth-basic")
 
-		client := http.Client{}
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: a.conf.Auth.Info.Insecure},
+		}
+		client := http.Client{Transport: tr}
 		res, err := client.Do(req)
 		if err != nil {
 			log.Printf("failed to retrieve organizations: %s", err)

--- a/conf.go
+++ b/conf.go
@@ -36,6 +36,7 @@ type AuthInfoConf struct {
 	RedirectURL  string `yaml:"redirect_url"`
 	Endpoint     string `yaml:"endpoint"`
 	ApiEndpoint  string `yaml:"api_endpoint"`
+	Insecure     bool   `yaml:"insecure"`
 }
 
 type ProxyConf struct {
@@ -50,7 +51,13 @@ func ParseConf(path string) (*Conf, error) {
 		return nil, err
 	}
 
-	c := &Conf{}
+	c := &Conf{
+		Auth: AuthConf{
+			Info: AuthInfoConf{
+				Insecure: false,
+			},
+		},
+	}
 	if err := yaml.Unmarshal(data, c); err != nil {
 		return nil, err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -140,4 +140,7 @@ auth:
 	if conf.Auth.Info.ApiEndpoint != "https://api.github.com" {
 		t.Errorf("unexpected api endpoint address: %s", conf.Auth.Info.ApiEndpoint)
 	}
+	if conf.Auth.Info.Insecure {
+		t.Errorf("insecure flag should be false: %s", conf.Auth.Info.Insecure)
+	}
 }


### PR DESCRIPTION
あんまりメインでは使わないのですが、確認時などにSSLのverifyを外せると楽な場合もあるので追加させていただけると助かります。

```
auth:
  info:
    insecure: false
```

default falseでSSLのverifyを外したいときだけ明示的にinsecure: trueにして利用します。
