### PR TITLE
Wait 2 goroutines

### DIFF
--- a/httpd.go
+++ b/httpd.go
@@ -137,7 +137,9 @@ func proxyHandleWrapper(u *url.URL, handler http.Handler) http.Handler {
 			}
 			go cp(d, nc)
 			go cp(nc, d)
-			<-errc
+			for i := 0; i < cap(errc); i++ {
+				<-errc
+			}
 		} else {
 			handler.ServeHTTP(w, r)
 		}


### PR DESCRIPTION
Original code, one goroutine may fails in following case.
 1 one goroutine sends error to channel
 2 waited function receives it from channel
 3 waited function finishes
 4 waited function closes 'nc' and 'd' in defer
 5 other goroutine fails io.Copy because 'nc' and 'd' are already closed.

コードを見て気になったのですが, 意味がまだ深く理解できていないので
間違っているかもしれません.
