### PR TITLE
Name based vhost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ auth:
     api_endpoint: https://github.yourcompany.com/api
 ```
 
+## Name Based Virtual Host
+
+An example of "Name Based Viatual Host" setting.
+
+```yaml
+auth:
+  session:
+    # authentication key for cookie store
+    key: secret123
+    # domain of virtual hosts base host
+    cookie_domain: gate.example.com
+
+# proxy definitions
+proxy:
+  - path: /
+    host: elasticsearch.gate.example.com
+    dest: http://127.0.0.1:9200
+
+  - path: /
+    host: influxdb.gate.example.com
+    dest: http://127.0.0.1:8086
+```
+
 ## License
 
 MIT

--- a/authenticator.go
+++ b/authenticator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/go-martini/martini"
 	gooauth2 "github.com/golang/oauth2"
 	"github.com/martini-contrib/oauth2"
@@ -9,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"fmt"
 )
 
 type Authenticator interface {
@@ -53,7 +53,7 @@ func GithubGeneral(opts *gooauth2.Options, conf *Conf) martini.Handler {
 
 type BaseAuth struct {
 	handler martini.Handler
-	conf *Conf
+	conf    *Conf
 }
 
 func (b *BaseAuth) Handler() martini.Handler {

--- a/conf.go
+++ b/conf.go
@@ -6,6 +6,10 @@ import (
 	"io/ioutil"
 )
 
+const (
+	noAuthServiceName = "nothing" // for testing only (undocumented)
+)
+
 type Conf struct {
 	Addr         string      `yaml:"address"`
 	SSL          SSLConf     `yaml:"ssl"`

--- a/conf.go
+++ b/conf.go
@@ -26,7 +26,8 @@ type AuthConf struct {
 }
 
 type AuthSessionConf struct {
-	Key string `yaml:"key"`
+	Key          string `yaml:"key"`
+	CookieDomain string `yaml:"cookie_domain"`
 }
 
 type AuthInfoConf struct {
@@ -42,6 +43,7 @@ type ProxyConf struct {
 	Path  string `yaml:"path"`
 	Dest  string `yaml:"dest"`
 	Strip bool   `yaml:"strip_path"`
+	Host  string `yaml:"host"`
 }
 
 func ParseConf(path string) (*Conf, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -141,3 +141,64 @@ auth:
 		t.Errorf("unexpected api endpoint address: %s", conf.Auth.Info.ApiEndpoint)
 	}
 }
+
+func TestParseNamebasedVhosts(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	data := `---
+address: ":9999"
+
+auth:
+  session:
+    key: secret
+    cookie_domain: example.com
+
+  info:
+    service: 'google'
+    client_id: 'secret client id'
+    client_secret: 'secret client secret'
+    redirect_url: 'http://example.com/oauth2callback'
+
+htdocs: ./
+
+proxy:
+  - path: /
+    host: elasticsearch.example.com
+    dest: http://127.0.0.1:9200
+  - path: /
+    host: influxdb.example.com
+    dest: http://127.0.0.1:8086
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if conf.Auth.Session.CookieDomain != "example.com" {
+		t.Errorf("unexpected cookie_domain: %s", conf.Auth.Session.CookieDomain)
+	}
+
+	if len(conf.Proxies) != 2 {
+		t.Errorf("insufficient proxy definions")
+	}
+	es := conf.Proxies[0]
+	if es.Path != "/" || es.Host != "elasticsearch.example.com" || es.Dest != "http://127.0.0.1:9200" {
+		t.Errorf("unexpected proxy[0]: %#v", es)
+	}
+
+	ifdb := conf.Proxies[1]
+	if ifdb.Path != "/" || ifdb.Host != "influxdb.example.com" || ifdb.Dest != "http://127.0.0.1:8086" {
+		t.Errorf("unexpected proxy[1]: %#v", ifdb)
+	}
+}

--- a/httpd.go
+++ b/httpd.go
@@ -25,6 +25,17 @@ type User struct {
 	Email string
 }
 
+type Backend struct {
+	Host      string
+	URL       *url.URL
+	Strip     bool
+	StripPath string
+}
+
+const (
+	BackendHostHeader = "X-Gate-Backend-Host"
+)
+
 func NewServer(conf *Conf) *Server {
 	return &Server{conf}
 }
@@ -33,11 +44,18 @@ func (s *Server) Run() error {
 	m := martini.Classic()
 	a := NewAuthenticator(s.Conf)
 
-	m.Use(sessions.Sessions("session", sessions.NewCookieStore([]byte(s.Conf.Auth.Session.Key))))
+	cookieStore := sessions.NewCookieStore([]byte(s.Conf.Auth.Session.Key))
+	if domain := s.Conf.Auth.Session.CookieDomain; domain != "" {
+		cookieStore.Options(sessions.Options{Domain: domain})
+	}
+	m.Use(sessions.Sessions("session", cookieStore))
 	m.Use(a.Handler())
 
 	m.Use(loginRequired())
 	m.Use(restrictRequest(s.Conf.Restrictions, a))
+
+	backendsFor := make(map[string][]Backend)
+	backendIndex := make([]string, len(s.Conf.Proxies))
 
 	for i := range s.Conf.Proxies {
 		p := s.Conf.Proxies[i]
@@ -55,15 +73,24 @@ func (s *Server) Run() error {
 		if err != nil {
 			return err
 		}
+		backendsFor[p.Path] = append(backendsFor[p.Path], Backend{
+			Host:      p.Host,
+			URL:       u,
+			Strip:     p.Strip,
+			StripPath: strip_path,
+		})
+		backendIndex[i] = p.Path
+		log.Printf("register proxy host:%s path:%s dest:%s strip_path:%v", p.Host, strip_path, u.String(), p.Strip)
+	}
 
-		proxy := httputil.NewSingleHostReverseProxy(u)
-		if p.Strip {
-			m.Any(p.Path, http.StripPrefix(strip_path, proxyHandleWrapper(u, proxy)))
-		} else {
-			m.Any(p.Path, proxyHandleWrapper(u, proxy))
+	registered := make(map[string]bool)
+	for _, path := range backendIndex {
+		if registered[path] {
+			continue
 		}
-
-		log.Printf("register proxy path:%s dest:%s", strip_path, u.String())
+		proxy := newVirtualHostReverseProxy(backendsFor[path])
+		m.Any(path, proxyHandleWrapper(proxy))
+		registered[path] = true
 	}
 
 	path, err := filepath.Abs(s.Conf.Htdocs)
@@ -84,6 +111,34 @@ func (s *Server) Run() error {
 	}
 }
 
+func newVirtualHostReverseProxy(backends []Backend) http.Handler {
+	bmap := make(map[string]Backend)
+	for _, b := range backends {
+		bmap[b.Host] = b
+	}
+	defaultBackend, ok := bmap[""]
+	if !ok {
+		defaultBackend = backends[0]
+	}
+
+	director := func(req *http.Request) {
+		b, ok := bmap[req.Host]
+		if !ok {
+			b = defaultBackend
+		}
+		req.URL.Scheme = b.URL.Scheme
+		req.URL.Host = b.URL.Host
+		if b.Strip {
+			if p := strings.TrimPrefix(req.URL.Path, b.StripPath); len(p) < len(req.URL.Path) {
+				req.URL.Path = "/" + p
+			}
+		}
+		req.Header.Set(BackendHostHeader, req.URL.Host)
+		log.Println("backend url", req.URL.String())
+	}
+	return &httputil.ReverseProxy{Director: director}
+}
+
 func isWebsocket(r *http.Request) bool {
 	if strings.ToLower(r.Header.Get("Connection")) == "upgrade" &&
 		strings.ToLower(r.Header.Get("Upgrade")) == "websocket" {
@@ -93,11 +148,16 @@ func isWebsocket(r *http.Request) bool {
 	}
 }
 
-func proxyHandleWrapper(u *url.URL, handler http.Handler) http.Handler {
+func proxyHandleWrapper(handler http.Handler) http.Handler {
+	proxy, _ := handler.(*httputil.ReverseProxy)
+	director := proxy.Director
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// websocket?
 		if isWebsocket(r) {
-			target := u.Host
+			director(r) // rewrite request headers for backend
+			target := r.Header.Get(BackendHostHeader)
+
 			if strings.HasPrefix(r.URL.Path, "/") == false {
 				r.URL.Path = "/" + r.URL.Path
 			}

--- a/httpd_test.go
+++ b/httpd_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPrepareFoo(t *testing.T) {
+	http.HandleFunc("/foo/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello Foo\n")
+	})
+	go func() {
+		err := http.ListenAndServe(":10001", nil)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	time.Sleep(1 * time.Second)
+}
+
+func TestPrepareBar(t *testing.T) {
+	http.HandleFunc("/bar/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello Bar\n")
+	})
+	go func() {
+		err := http.ListenAndServe(":10002", nil)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	time.Sleep(1 * time.Second)
+}
+
+func TestRunHTTPd(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	data := `
+address: "127.0.0.1:9999"
+auth:
+  session:
+    key: dummy
+  info:
+    service: nothing
+    client_id: dummy
+    client_secret: dummy
+    redirect_url: "http://example.com/oauth2callback"
+proxy:
+  - path: /foo
+    dest: http://127.0.0.1:10001
+    strip_path: no
+
+  - path: /bar
+    dest: http://127.0.0.1:10002
+    strip_path: no
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+	server := NewServer(conf)
+	if server == nil {
+		t.Error("NewServer failed")
+	}
+	go server.Run()
+	time.Sleep(1 * time.Second)
+
+	// backend foo
+	if res, err := http.Get("http://127.0.0.1:9999/foo/"); err == nil {
+		defer res.Body.Close()
+		body, _ := ioutil.ReadAll(res.Body)
+		if string(body) != "hello Foo\n" {
+			t.Errorf("unexpected foo body %s", body)
+		}
+	} else {
+		t.Error(err)
+	}
+
+	// backend bar
+	if res, err := http.Get("http://127.0.0.1:9999/bar/"); err == nil {
+		defer res.Body.Close()
+		body, _ := ioutil.ReadAll(res.Body)
+		if string(body) != "hello Bar\n" {
+			t.Errorf("unexpected bar body %s", body)
+		}
+	} else {
+		t.Error(err)
+	}
+}
+
+func TestRunVhost(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	data := `
+address: "127.0.0.1:10000"
+auth:
+  session:
+    key: dummy
+    cookie_domain: example.com
+  info:
+    service: nothing
+    client_id: dummy
+    client_secret: dummy
+    redirect_url: "http://example.com/oauth2callback"
+proxy:
+  - path: /
+    dest: http://127.0.0.1:10001
+    strip_path: no
+    host: foo.example.com
+
+  - path: /
+    dest: http://127.0.0.1:10002
+    strip_path: no
+    host: bar.example.com
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+	server := NewServer(conf)
+	if server == nil {
+		t.Error("NewServer failed")
+	}
+	go server.Run()
+	time.Sleep(1 * time.Second)
+
+	var req *http.Request
+	client := &http.Client{}
+
+	// backend foo
+	req, _ = http.NewRequest("GET", "http://127.0.0.1:10000/foo/", nil)
+	req.Header.Add("Host", "foo.example.com")
+	if res, err := client.Do(req); err == nil {
+		defer res.Body.Close()
+		body, _ := ioutil.ReadAll(res.Body)
+		if string(body) != "hello Foo\n" {
+			t.Errorf("unexpected foo body %s", body)
+		}
+	} else {
+		t.Error(err)
+	}
+
+	// backend bar
+	req, _ = http.NewRequest("GET", "http://127.0.0.1:10000/bar/", nil)
+	req.Header.Add("Host", "bar.example.com")
+	if res, err := http.Get("http://127.0.0.1:10000/bar/"); err == nil {
+		defer res.Body.Close()
+		body, _ := ioutil.ReadAll(res.Body)
+		if string(body) != "hello Bar\n" {
+			t.Errorf("unexpected bar body %s", body)
+		}
+	} else {
+		t.Error(err)
+	}
+
+}


### PR DESCRIPTION
I supported name based virtual host.
- Add Conf.Proxies[].Host : virtual host header.
- Add Conf.Session.CookieDomain: cookie's domain of the gate instance. It must be match all virtual hosts domain name.
