### PR TITLE
Add authenticated user info to HTTP header

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -115,7 +115,9 @@ func (a *GoogleAuth) Authenticate(domain []string, c martini.Context, tokens oau
 		if user != nil {
 			log.Printf("user %s logged in", email)
 			c.Map(user)
-			r.Header.Set(a.conf.Auth.Header.UserKey, email)
+			if userKey := a.conf.Auth.Header.UserKey; userKey != "" {
+				r.Header.Set(userKey, email)
+			}
 		} else {
 			log.Printf("email doesn't allow: %s", email)
 			forbidden(w)

--- a/authenticator.go
+++ b/authenticator.go
@@ -115,6 +115,7 @@ func (a *GoogleAuth) Authenticate(domain []string, c martini.Context, tokens oau
 		if user != nil {
 			log.Printf("user %s logged in", email)
 			c.Map(user)
+			r.Header.Set(a.conf.Auth.Header.UserKey, email)
 		} else {
 			log.Printf("email doesn't allow: %s", email)
 			forbidden(w)

--- a/conf.go
+++ b/conf.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 )
 
+const AuthHeaderUserKeyDefault = "x-gate-user"
+
 type Conf struct {
 	Addr         string      `yaml:"address"`
 	SSL          SSLConf     `yaml:"ssl"`
@@ -23,6 +25,7 @@ type SSLConf struct {
 type AuthConf struct {
 	Session AuthSessionConf `yaml:"session"`
 	Info    AuthInfoConf    `yaml:"info"`
+	Header  AuthHeaderConf  `yaml:"header"`
 }
 
 type AuthSessionConf struct {
@@ -36,6 +39,10 @@ type AuthInfoConf struct {
 	RedirectURL  string `yaml:"redirect_url"`
 	Endpoint     string `yaml:"endpoint"`
 	ApiEndpoint  string `yaml:"api_endpoint"`
+}
+
+type AuthHeaderConf struct {
+	UserKey string `yaml:"user_key"`
 }
 
 type ProxyConf struct {
@@ -73,6 +80,10 @@ func ParseConf(path string) (*Conf, error) {
 	}
 	if c.Auth.Info.RedirectURL == "" {
 		return nil, errors.New("auth.info.redirect_url config is required")
+	}
+
+	if c.Auth.Header.UserKey == "" {
+		c.Auth.Header.UserKey = AuthHeaderUserKeyDefault
 	}
 
 	if c.Htdocs == "" {

--- a/conf.go
+++ b/conf.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 )
 
-const AuthHeaderUserKeyDefault = "x-gate-user"
-
 type Conf struct {
 	Addr         string      `yaml:"address"`
 	SSL          SSLConf     `yaml:"ssl"`
@@ -80,10 +78,6 @@ func ParseConf(path string) (*Conf, error) {
 	}
 	if c.Auth.Info.RedirectURL == "" {
 		return nil, errors.New("auth.info.redirect_url config is required")
-	}
-
-	if c.Auth.Header.UserKey == "" {
-		c.Auth.Header.UserKey = AuthHeaderUserKeyDefault
 	}
 
 	if c.Htdocs == "" {

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -20,9 +20,9 @@ auth:
     # your app redirect_url for the service: if the service is Google, path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
-#  # HTTP request header definitions
+#  # HTTP request header definitions (optional)
 #  header:
-#    user_key: x-gate-user # field name for authenticated user info
+#    user_key: x-gate-user # field name for authenticated user info (default: x-gate-user)
 
 # # restrict user request. (optional)
 # restrictions:

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -22,7 +22,7 @@ auth:
 
 #  # HTTP request header definitions (optional)
 #  header:
-#    user_key: x-gate-user # field name for authenticated user info (default: x-gate-user)
+#    user_key: your key # field name for authenticated user info (ex. x-gate-user)
 
 # # restrict user request. (optional)
 # restrictions:

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -20,6 +20,10 @@ auth:
     # your app redirect_url for the service: if the service is Google, path is always "/oauth2callback"
     redirect_url: https://yourapp.example.com/oauth2callback
 
+#  # HTTP request header definitions
+#  header:
+#    user_key: x-gate-user # field name for authenticated user info
+
 # # restrict user request. (optional)
 # restrictions:
 #   - yourdomain.com    # domain of your Google App (Google)

--- a/config_test.go
+++ b/config_test.go
@@ -29,6 +29,9 @@ auth:
     client_secret: 'secret client secret'
     redirect_url: 'http://example.com/oauth2callback'
 
+  header:
+    user_key: 'x-gate-user'
+
 htdocs: ./
 
 proxy:
@@ -49,54 +52,7 @@ proxy:
 		t.Errorf("unexpected address: %s", conf.Addr)
 	}
 
-	if conf.Auth.Header.UserKey != AuthHeaderUserKeyDefault {
-		t.Errorf("unexpected auth header user key: %s", conf.Auth.Header.UserKey)
-	}
-}
-
-func TestParseAuthHeader(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		f.Close()
-		os.Remove(f.Name())
-	}()
-
-	data := `---
-address: ":9999"
-
-auth:
-  session:
-    key: secret
-
-  info:
-    service: 'google'
-    client_id: 'secret client id'
-    client_secret: 'secret client secret'
-    redirect_url: 'http://example.com/oauth2callback'
-
-  header:
-    user_key: 'auth-header-user-key'
-
-htdocs: ./
-
-proxy:
-  - path: /foo
-    dest: http://example.com/bar
-    strip_path: yes
-`
-	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
-		t.Error(err)
-	}
-
-	conf, err := ParseConf(f.Name())
-	if err != nil {
-		t.Error(err)
-	}
-
-	if conf.Auth.Header.UserKey != "auth-header-user-key" {
+	if conf.Auth.Header.UserKey != "x-gate-user" {
 		t.Errorf("unexpected auth header user key: %s", conf.Auth.Header.UserKey)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -48,6 +48,57 @@ proxy:
 	if conf.Addr != ":9999" {
 		t.Errorf("unexpected address: %s", conf.Addr)
 	}
+
+	if conf.Auth.Header.UserKey != AuthHeaderUserKeyDefault {
+		t.Errorf("unexpected auth header user key: %s", conf.Auth.Header.UserKey)
+	}
+}
+
+func TestParseAuthHeader(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	data := `---
+address: ":9999"
+
+auth:
+  session:
+    key: secret
+
+  info:
+    service: 'google'
+    client_id: 'secret client id'
+    client_secret: 'secret client secret'
+    redirect_url: 'http://example.com/oauth2callback'
+
+  header:
+    user_key: 'auth-header-user-key'
+
+htdocs: ./
+
+proxy:
+  - path: /foo
+    dest: http://example.com/bar
+    strip_path: yes
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if conf.Auth.Header.UserKey != "auth-header-user-key" {
+		t.Errorf("unexpected auth header user key: %s", conf.Auth.Header.UserKey)
+	}
 }
 
 func TestParseMultiRestrictions(t *testing.T) {


### PR DESCRIPTION
gate で認証をかけている管理画面などで、権限のある人しか実行できない操作を実装したいので、認証したユーザーの情報を HTTP ヘッダーに追加し、プロキシ先のアプリケーションなどで取得できるようにしました。

とりあえず、提案という意味合いも含め、直近で使用したい Google の認証の方にだけ実装しています。

いかがでしょう…？
