### PR TITLE
Compatibility with newer golang/oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.yml
 gate
+/.gondler/

--- a/Gomfile
+++ b/Gomfile
@@ -1,0 +1,6 @@
+# vim: ft=ruby
+itself "github.com/typester/gate"
+gom "github.com/go-martini/martini"
+gom "github.com/golang/oauth2"
+gom "github.com/sorah/oauth2", branch: 'origin/oauth2-compat', as: 'github.com/martini-contrib/oauth2' # https://github.com/martini-contrib/oauth2/pull/36
+gom "github.com/martini-contrib/sessions"

--- a/Gomfile
+++ b/Gomfile
@@ -4,3 +4,4 @@ gom "github.com/go-martini/martini"
 gom "github.com/golang/oauth2"
 gom "github.com/sorah/oauth2", branch: 'origin/oauth2-compat', as: 'github.com/martini-contrib/oauth2' # https://github.com/martini-contrib/oauth2/pull/36
 gom "github.com/martini-contrib/sessions"
+gom "gopkg.in/yaml.v1"

--- a/authenticator.go
+++ b/authenticator.go
@@ -65,14 +65,14 @@ type GoogleAuth struct {
 }
 
 func (a *GoogleAuth) Authenticate(domain []string, c martini.Context, tokens oauth2.Tokens, w http.ResponseWriter, r *http.Request) {
-	extra := tokens.ExtraData()
-	if _, ok := extra["id_token"]; ok == false {
+	idToken := tokens.Extra("id_token")
+	if len(idToken) == 0 {
 		log.Printf("id_token not found")
 		forbidden(w)
 		return
 	}
 
-	keys := strings.Split(extra["id_token"], ".")
+	keys := strings.Split(idToken, ".")
 	if len(keys) < 2 {
 		log.Printf("invalid id_token")
 		forbidden(w)


### PR DESCRIPTION
This pull request requires martini-contrib/oauth#36.

So it means this is early pull request, I'm not hurry to merge before martini-contrib/oauth#36 gets merged.
- Added [Gomfile](https://github.com/rosylilly/gondler) to declare dependencies
  - Temporarily points my topic branch
