### PR TITLE
Allow customize oauth2 paths

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
+	"github.com/martini-contrib/oauth2"
 )
 
 type Conf struct {
@@ -12,6 +13,7 @@ type Conf struct {
 	Auth         AuthConf    `yaml:"auth"`
 	Restrictions []string    `yaml:"restrictions"`
 	Proxies      []ProxyConf `yaml:"proxy"`
+	Paths        PathConf    `yaml:"paths"`
 	Htdocs       string      `yaml:"htdocs"`
 }
 
@@ -42,6 +44,13 @@ type ProxyConf struct {
 	Path  string `yaml:"path"`
 	Dest  string `yaml:"dest"`
 	Strip bool   `yaml:"strip_path"`
+}
+
+type PathConf struct {
+	Login    string `yaml:"login"`
+	Logout   string `yaml:"logout"`
+	Callback string `yaml:"callback"`
+	Error    string `yaml:"error"`
 }
 
 func ParseConf(path string) (*Conf, error) {
@@ -87,4 +96,19 @@ func ParseConf(path string) (*Conf, error) {
 	}
 
 	return c, nil
+}
+
+func (c *Conf) SetOAuth2Paths() {
+	if c.Paths.Login != "" {
+		oauth2.PathLogin = c.Paths.Login
+	}
+	if c.Paths.Logout != "" {
+		oauth2.PathLogout = c.Paths.Logout
+	}
+	if c.Paths.Callback != "" {
+		oauth2.PathCallback = c.Paths.Callback
+	}
+	if c.Paths.Error != "" {
+		oauth2.PathError = c.Paths.Error
+	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"github.com/martini-contrib/oauth2"
 )
 
 func TestParse(t *testing.T) {
@@ -139,5 +140,59 @@ auth:
 	}
 	if conf.Auth.Info.ApiEndpoint != "https://api.github.com" {
 		t.Errorf("unexpected api endpoint address: %s", conf.Auth.Info.ApiEndpoint)
+	}
+}
+
+func TestPathConf(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	data := `---
+address: ":9999"
+
+auth:
+  session:
+    key: secret
+
+  info:
+    service: 'github'
+    client_id: 'secret client id'
+    client_secret: 'secret client secret'
+    redirect_url: 'http://example.com/_gate_callback'
+
+paths:
+    login: "/_gate_login"
+    logout: "/_gate_logout"
+    callback: "/_gate_callback"
+    error: "/_gate_error"
+`
+	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
+		t.Error(err)
+	}
+
+	conf, err := ParseConf(f.Name())
+	if err != nil {
+		t.Error(err)
+	}
+
+	conf.SetOAuth2Paths()
+
+	if oauth2.PathLogin != "/_gate_login" {
+		t.Errorf("unexpected oauth2.PathLogin: %s", oauth2.PathLogin)
+	}
+	if oauth2.PathLogout != "/_gate_logout" {
+		t.Errorf("unexpected oauth2.PathLogout: %s", oauth2.PathLogout)
+	}
+	if oauth2.PathCallback != "/_gate_callback" {
+		t.Errorf("unexpected oauth2.PathCallback: %s", oauth2.PathCallback)
+	}
+	if oauth2.PathError != "/_gate_error" {
+		t.Errorf("unexpected oauth2.PathError: %s", oauth2.PathError)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ func main() {
 		panic(err)
 	}
 
+	conf.SetOAuth2Paths()
+
 	server := NewServer(conf)
 	log.Fatal(server.Run())
 }


### PR DESCRIPTION
We have `/login` in backend servers, so it shouldn't be taken by the Gate.

``` yaml
paths:
    login: "/_gate_login"
    logout: "/_gate_logout"
    callback: "/_gate_callback"
    error: "/_gate_error"
```
