### PR TITLE
Set FlushInterval when initializing httputil.ReverseProxy

### DIFF
--- a/httpd.go
+++ b/httpd.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/oauth2"
@@ -147,7 +148,7 @@ func newVirtualHostReverseProxy(backends []Backend) http.Handler {
 		req.Header.Set(BackendHostHeader, req.URL.Host)
 		log.Println("backend url", req.URL.String())
 	}
-	return &httputil.ReverseProxy{Director: director}
+	return &httputil.ReverseProxy{Director: director, FlushInterval: 500 * time.Millisecond}
 }
 
 func isWebsocket(r *http.Request) bool {


### PR DESCRIPTION
Due to httputil.ReverseProxy's buffering behavior, I have to wait before HTTP 1.1 Transfer-Encoding: chunked response to start being sent. Setting FlushInterval to httputil.ReverseProxy solves this issue.

Hard-coding the flush interval of 500ms may be arguable.

Note: due to martini-contrib/oauth2's incompatible changes, this branch can't be merged to current master...
