### PR TITLE
Fix bug where WebSocket's close wasn't sent to client

### DIFF
--- a/httpd.go
+++ b/httpd.go
@@ -192,8 +192,6 @@ func proxyHandleWrapper(handler http.Handler) http.Handler {
 				log.Printf("Hijack error: %v", err)
 				return
 			}
-			defer nc.Close()
-			defer d.Close()
 
 			err = r.Write(d)
 			if err != nil {
@@ -202,9 +200,10 @@ func proxyHandleWrapper(handler http.Handler) http.Handler {
 			}
 
 			errc := make(chan error, 2)
-			cp := func(dst io.Writer, src io.Reader) {
+			cp := func(dst io.WriteCloser, src io.ReadCloser) {
 				_, err := io.Copy(dst, src)
 				errc <- err
+				dst.Close()
 			}
 			go cp(d, nc)
 			go cp(nc, d)


### PR DESCRIPTION
At the moment, gate keeps holding the connection when the server closes a WebSocket connection through gate. Therefore, `onclose` of JavaScript's WebSocket object never gets called.

To be honest, I'm not too sure why this patch solves the problem... but I got it from studying another WebSocket proxy.

https://github.com/joinmytalk/drunken-hipster/blob/master/main.go#L49-L65
