### PR TITLE
allow customize cookie settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ auth:
   session:
     # authentication key for cookie store
     key: secret123
+    cookie:
+        # cookie path(default: "/")
+        path: /
+        # Max-Age attribute present and given in seconds(default: no 'Max-Age' specified)
+        max_age: 0
+        secure: no
+        http_only: no
 
   info:
     # oauth2 provider name (`google` or `github`)
@@ -118,7 +125,10 @@ auth:
   session:
     # authentication key for cookie store
     key: secret123
-    # domain of virtual hosts base host
+    cookie:
+        # domain of virtual hosts base host
+        domain: gate.example.com
+    # domain of virtual hosts base host(DEPRECATED)
     cookie_domain: gate.example.com
 
 # proxy definitions

--- a/conf.go
+++ b/conf.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"errors"
+	"github.com/martini-contrib/oauth2"
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
-	"github.com/martini-contrib/oauth2"
 )
 
 const (
@@ -32,8 +32,17 @@ type AuthConf struct {
 }
 
 type AuthSessionConf struct {
-	Key          string `yaml:"key"`
-	CookieDomain string `yaml:"cookie_domain"`
+	Key          string      `yaml:"key"`
+	CookieDomain string      `yaml:"cookie_domain"`
+	Cookie       *CookieConf `yaml:"cookie"`
+}
+
+type CookieConf struct {
+	Path     string `yaml:"path"`
+	Domain   string `yaml:"domain"`
+	MaxAge   int    `yaml:"max_age"`
+	Secure   bool   `yaml:"secure"`
+	HttpOnly bool   `yaml:"http_only"`
 }
 
 type AuthInfoConf struct {

--- a/httpd.go
+++ b/httpd.go
@@ -43,18 +43,24 @@ func (s *Server) Run() error {
 	m := martini.Classic()
 
 	cookieStore := sessions.NewCookieStore([]byte(s.Conf.Auth.Session.Key))
+	cookieOption := sessions.Options{}
 	if domain := s.Conf.Auth.Session.CookieDomain; domain != "" {
-		cookieStore.Options(sessions.Options{Domain: domain})
+		log.Printf("WARNING: auth.session.cookie_domain is DEPRECATED! you should use auth.session.cookie.domain")
+		cookieOption.Domain = domain
 	}
 	if cookie := s.Conf.Auth.Session.Cookie; cookie != nil {
-		cookieStore.Options(sessions.Options{
+		cookieOption = sessions.Options{
 			Path:     cookie.Path,
 			Domain:   cookie.Domain,
 			MaxAge:   cookie.MaxAge,
 			Secure:   cookie.Secure,
 			HttpOnly: cookie.HttpOnly,
-		})
+		}
 	}
+	if cookieOption.Path == "" {
+		cookieOption.Path = "/"
+	}
+	cookieStore.Options(cookieOption)
 
 	m.Use(sessions.Sessions("session", cookieStore))
 

--- a/httpd.go
+++ b/httpd.go
@@ -46,6 +46,16 @@ func (s *Server) Run() error {
 	if domain := s.Conf.Auth.Session.CookieDomain; domain != "" {
 		cookieStore.Options(sessions.Options{Domain: domain})
 	}
+	if cookie := s.Conf.Auth.Session.Cookie; cookie != nil {
+		cookieStore.Options(sessions.Options{
+			Path:     cookie.Path,
+			Domain:   cookie.Domain,
+			MaxAge:   cookie.MaxAge,
+			Secure:   cookie.Secure,
+			HttpOnly: cookie.HttpOnly,
+		})
+	}
+
 	m.Use(sessions.Sessions("session", cookieStore))
 
 	if s.Conf.Auth.Info.Service != noAuthServiceName {

--- a/httpd_test.go
+++ b/httpd_test.go
@@ -114,7 +114,8 @@ address: "127.0.0.1:10000"
 auth:
   session:
     key: dummy
-    cookie_domain: example.com
+    cookie:
+        domain: example.com
   info:
     service: nothing
     client_id: dummy


### PR DESCRIPTION
cookieのdomain以外の属性もconfigで設定できるようにする修正です。

path属性が指定されていないことが原因でredirect loopになってしまうのを防ぐことが目的です。
今はpath属性を付けないので、以下のようにリダイレクトループが発生してしまいます。
1. 「/foo/bar」にアクセスする際、認証がexpireしていたらcookieに保存された認証情報を削除する 
   - このときcookieのpath属性が指定されていないので、ブラウザは「path=/foo」が指定されたと解釈する
2. 「/login」へリダイレクトしてログイン処理を行う
3. 認証完了後「/oauth2callback」へ戻ってきて、cookieに認証情報を追加する
   - ブラウザはcookieのpath属性に「path=/」が指定されたと解釈する
4. 「/foo/bar」へリダイレクトするがすぐに「/login」へリダイレクトしてしまいリダイレクトループに陥る
   - 「/oauth2callback」と「/foo/bar」でcookieのパス属性が異なるので、別物として扱われる
   - 「path=/」はログイン済みと認識されるが、「/foo」以下は未ログインとして認識されてしまう
