### PR TITLE
Update Dependencies

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -3,13 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-martini/martini"
-	gooauth2 "github.com/golang/oauth2"
-	"github.com/martini-contrib/oauth2"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/go-martini/martini"
+	"github.com/martini-contrib/oauth2"
+	gooauth2 "golang.org/x/oauth2"
 )
 
 type Authenticator interface {

--- a/authenticator.go
+++ b/authenticator.go
@@ -21,7 +21,7 @@ func NewAuthenticator(conf *Conf) Authenticator {
 	var authenticator Authenticator
 
 	if conf.Auth.Info.Service == "google" {
-		handler := oauth2.Google(&gooauth2.Options{
+		handler := oauth2.Google(&gooauth2.Config{
 			ClientID:     conf.Auth.Info.ClientId,
 			ClientSecret: conf.Auth.Info.ClientSecret,
 			RedirectURL:  conf.Auth.Info.RedirectURL,
@@ -29,7 +29,7 @@ func NewAuthenticator(conf *Conf) Authenticator {
 		})
 		authenticator = &GoogleAuth{&BaseAuth{handler, conf}}
 	} else if conf.Auth.Info.Service == "github" {
-		handler := GithubGeneral(&gooauth2.Options{
+		handler := GithubGeneral(&gooauth2.Config{
 			ClientID:     conf.Auth.Info.ClientId,
 			ClientSecret: conf.Auth.Info.ClientSecret,
 			RedirectURL:  conf.Auth.Info.RedirectURL,
@@ -44,11 +44,13 @@ func NewAuthenticator(conf *Conf) Authenticator {
 }
 
 // Currently, martini-contrib/oauth2 doesn't support github enterprise directly.
-func GithubGeneral(opts *gooauth2.Options, conf *Conf) martini.Handler {
-	authUrl := fmt.Sprintf("%s/login/oauth/authorize", conf.Auth.Info.Endpoint)
-	tokenUrl := fmt.Sprintf("%s/login/oauth/access_token", conf.Auth.Info.Endpoint)
+func GithubGeneral(cfgs *gooauth2.Config, conf *Conf) martini.Handler {
+	cfgs.Endpoint = gooauth2.Endpoint{
+		AuthURL:  fmt.Sprintf("%s/login/oauth/authorize", conf.Auth.Info.Endpoint),
+		TokenURL: fmt.Sprintf("%s/login/oauth/access_token", conf.Auth.Info.Endpoint),
+	}
 
-	return oauth2.NewOAuth2Provider(opts, authUrl, tokenUrl)
+	return oauth2.NewOAuth2Provider(cfgs)
 }
 
 type BaseAuth struct {

--- a/httpd.go
+++ b/httpd.go
@@ -98,7 +98,7 @@ func (s *Server) Run() error {
 		registered[path] = true
 		rawPath := rawPaths[i]
 		if rawPath != "" {
-			m.Get(rawPath, func(w http.ResponseWriter, r *http.Request) {
+			m.Any(rawPath, func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, rawPath+"/", http.StatusFound)
 			})
 		}
@@ -111,7 +111,7 @@ func (s *Server) Run() error {
 
 	log.Printf("starting static file server for: %s", path)
 	fileServer := http.FileServer(http.Dir(path))
-	m.Get("/**", fileServer.ServeHTTP)
+	m.Any("/**", fileServer.ServeHTTP)
 
 	log.Printf("starting server at %s", s.Conf.Addr)
 


### PR DESCRIPTION
Hi typester, 

Recently golang.org/x/oauth2 and github.com/martini-contrib/oauth2 updated without compatibility.
Now gate does not work latest dependent libraries. This PR will fix this issue.

Changes:
- change from golang.org/x/oauth2.Options to golang.org/x/oauth2.Config
- request https://www.googleapis.com/oauth2/v3/userinfo (get url from openid-configuration) to get email (avoid to use old oauth2.Token.ExtraData())
